### PR TITLE
Fix initial synchronous report

### DIFF
--- a/changelog/v0.1.3/fix-synchronous-report.yaml
+++ b/changelog/v0.1.3/fix-synchronous-report.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Ensure initial report completes synchronously in the same goroutine as the user of the client
+    issueLink: https://github.com/solo-io/reporting-client/issues/12

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Reporting client", func() {
 	// given a channel, build a function that forwards the request onto that channel
 	var requestSender = func(reportChannel chan *v1.UsageRequest) func(ctx context.Context, request *v1.UsageRequest) (*v1.UsageResponse, error) {
 		return func(ctx context.Context, request *v1.UsageRequest) (*v1.UsageResponse, error) {
-			reportChannel <- request
+			// nothing may be listening on the report channel yet, so this expression may block. Let that happen in a new goroutine
+			go func() { reportChannel <- request }()
 			return &v1.UsageResponse{}, nil
 		}
 	}


### PR DESCRIPTION
Ensure initial report completes synchronously in the same goroutine as the user of the client
BOT NOTES: 
resolves https://github.com/solo-io/reporting-client/issues/12