### PR TITLE
add context to needed function

### DIFF
--- a/changelog/v0.1.4/add-context-to-payload.yaml
+++ b/changelog/v0.1.4/add-context-to-payload.yaml
@@ -2,3 +2,4 @@ changelog:
   - type: NON_USER_FACING
     description: Add context as input of UsagePayloadReader interface's GetPayload function. Needed for gloo k8s upgrade.
     issueLink: https://github.com/solo-io/gloo/issues/3579
+    resolvesIssue: false

--- a/changelog/v0.1.4/add-context-to-payload.yaml
+++ b/changelog/v0.1.4/add-context-to-payload.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add context as input of UsagePayloadReader interface's GetPayload function. Needed for gloo k8s upgrade.
+    issueLink: https://github.com/solo-io/gloo/issues/3579

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ type testPayloadReader struct {
 
 var _ client.UsagePayloadReader = &testPayloadReader{}
 
-func (p *testPayloadReader) GetPayload() (map[string]string, error) {
+func (p *testPayloadReader) GetPayload(ctx context.Context) (map[string]string, error) {
 	return map[string]string{}, nil
 }
 

--- a/pkg/api/v1/reporting.pb.go
+++ b/pkg/api/v1/reporting.pb.go
@@ -179,7 +179,7 @@ func (m *UsageRequest) GetInstanceMetadata() *InstanceMetadata {
 	return nil
 }
 
-func (m *UsageRequest) GetPayload() map[string]string {
+func (m *UsageRequest) GetPayload(ctx context.Context) map[string]string {
 	if m != nil {
 		return m.Payload
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,7 +26,7 @@ const (
 
 // a type that knows how to load the usage payload you want to report
 type UsagePayloadReader interface {
-	GetPayload() (map[string]string, error)
+	GetPayload(ctx context.Context) (map[string]string, error)
 }
 
 type CloseableConnection interface {
@@ -150,7 +150,7 @@ func (c *client) StartReportingUsage(ctx context.Context, interval time.Duration
 type errorHandler func(ctx context.Context, err error)
 
 func (c *client) sendUsage(ctx context.Context, errorHandler errorHandler) {
-	payload, err := c.usagePayloadReader.GetPayload()
+	payload, err := c.usagePayloadReader.GetPayload(ctx)
 	if err != nil {
 		errorHandler(ctx, ErrorReadingPayload(err))
 		return

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -26,7 +26,7 @@ type testReader struct {
 	payload map[string]string
 }
 
-func (t *testReader) GetPayload() (map[string]string, error) {
+func (t *testReader) GetPayload(ctx context.Context) (map[string]string, error) {
 	return t.payload, nil
 }
 

--- a/pkg/client/mocks/mock_usage_payload_reader.go
+++ b/pkg/client/mocks/mock_usage_payload_reader.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -34,7 +35,7 @@ func (m *MockUsagePayloadReader) EXPECT() *MockUsagePayloadReaderMockRecorder {
 }
 
 // GetPayload mocks base method
-func (m *MockUsagePayloadReader) GetPayload() (map[string]string, error) {
+func (m *MockUsagePayloadReader) GetPayload(ctx context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPayload")
 	ret0, _ := ret[0].(map[string]string)
@@ -43,7 +44,7 @@ func (m *MockUsagePayloadReader) GetPayload() (map[string]string, error) {
 }
 
 // GetPayload indicates an expected call of GetPayload
-func (mr *MockUsagePayloadReaderMockRecorder) GetPayload() *gomock.Call {
+func (mr *MockUsagePayloadReaderMockRecorder) GetPayload(ctx context.Context) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayload", reflect.TypeOf((*MockUsagePayloadReader)(nil).GetPayload))
 }


### PR DESCRIPTION
Needed for the gloo repo k8s 0.18 upgrade. Gloo has some structs which implement UsagePayloadReader, and one of these implementations of the GetPayload function eventually calls updated k8s functions that now require a context. 
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3579